### PR TITLE
Adding Save Storage Setting support

### DIFF
--- a/DeepStorage/packages.config
+++ b/DeepStorage/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Lib.Harmony" version="2.0.0.8" targetFramework="net472" />
+  <package id="SaveStorageSettingsUtil" version="1.1.0.1" targetFramework="net472" />
   <package id="UnlimitedHugs.Rimworld.HugsLib" version="7.1.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This will add support for the Save Storage Settings mod.

All Deep Storages will share saved storage settings for `stockpile` storages. This is a catch-all and will not break if a setting cannot be applied to a storage type (like medical settings being applied to a hayloft)

Load order does not matter. Save Storage Settings can be loaded before, after, or not at all (in which case the save/load setting buttons will not appear)

In the CompDeepStorage.cs code I decided to wrap the SaveStorageSettingUtil gizmo call inside a check to make sure parent is a Building_Storage to be defensive. If you'd prefer to make it one line it'd be
`SaveStorageSettingsGizmoUtil.AddSaveLoadGizmos(gizmos, SaveTypeEnum.Zone_Stockpile, (base.parent as Building_Storage).settings.filter);`

Final Note:
This does require the nuget package SaveStorageSettingsUtil. That dll _will_ need to be copied into the mod's 1.1 assembly folder unlike harmony/hugs

