### PR TITLE
Fix Tantrum: remove contents of LWM storages from targets (to smash) list

### DIFF
--- a/DeepStorage/LWM.DeepStorage.csproj
+++ b/DeepStorage/LWM.DeepStorage.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -69,6 +69,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Patch_TantrumMentalStateUtility_CanSmash.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Mod.cs" />
     <Compile Include="ModHugsLib.cs" />

--- a/DeepStorage/Patch_TantrumMentalStateUtility_CanSmash.cs
+++ b/DeepStorage/Patch_TantrumMentalStateUtility_CanSmash.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace LWM.DeepStorage
+{
+	[HarmonyPatch(typeof(TantrumMentalStateUtility), "CanSmash")]
+	internal class Patch_TantrumMentalStateUtility_CanSmash
+	{
+		// Token: 0x06000154 RID: 340 RVA: 0x0000BFA8 File Offset: 0x0000A1A8
+		[HarmonyPostfix]
+		private static void AfterCanSmash(Pawn pawn, Thing thing, ref bool __result)
+		{
+			if (__result && (!(thing is ThingWithComps) || thing.TryGetComp<CompDeepStorage>() == null))
+			{
+				SlotGroup slotGroup = thing.Position.GetSlotGroup(pawn.Map);
+				ThingWithComps thingWithComps = ((slotGroup != null) ? slotGroup.parent : null) as ThingWithComps;
+				CompDeepStorage compDeepStorage = (thingWithComps != null) ? thingWithComps.GetComp<CompDeepStorage>() : null;
+				__result = (compDeepStorage == null);
+			}
+		}
+	}
+}


### PR DESCRIPTION
At Tantrum breakdown pawn can smash any things which placed to LWM storage.
For example, pawn can smash ammunition which placed to chest.

This patch remove content of LWM storages from target list to prevent it.
[Related PR](https://github.com/skyarkhangel/Hardcore-SK/pull/2733)