### PR TITLE
Add Hemogen Packs to medicine cabinets

### DIFF
--- a/_Mod/LWM.DeepStorage/1.4/Defs/Deep_Storage.xml
+++ b/_Mod/LWM.DeepStorage/1.4/Defs/Deep_Storage.xml
@@ -793,6 +793,7 @@ Note: tossing large amounts of steel in willy-nilly means that it takes a while 
             <li>Drugs</li><!-- Kafouille asked for this.  Makes sense. -->
           </categories>
           <thingDefs>
+            <li>HemogenPack</li>
             <li>Neutroamine</li>
             <!--<li>Penoxycyline</li>Under drugs now!-->
           </thingDefs>

--- a/_Mod/LWM.DeepStorage/1.4/Defs/Deep_Storage.xml
+++ b/_Mod/LWM.DeepStorage/1.4/Defs/Deep_Storage.xml
@@ -793,7 +793,7 @@ Note: tossing large amounts of steel in willy-nilly means that it takes a while 
             <li>Drugs</li><!-- Kafouille asked for this.  Makes sense. -->
           </categories>
           <thingDefs>
-            <li>HemogenPack</li>
+            <li MayRequire="Ludeon.RimWorld.Biotech">HemogenPack</li>
             <li>Neutroamine</li>
             <!--<li>Penoxycyline</li>Under drugs now!-->
           </thingDefs>


### PR DESCRIPTION
It would make sense for Hemogen Packs (which are used for transfusion and extracted by surgery) to be stored in medicine cabinets, so I made a patch for it.