### PR TITLE
[WIP] Use grouping labels from 1.5

### DIFF
--- a/DeepStorage/CompDeepStorage.cs
+++ b/DeepStorage/CompDeepStorage.cs
@@ -12,7 +12,18 @@ using static LWM.DeepStorage.Utils.DBF; // trace utils
 
 namespace LWM.DeepStorage
 {
-    public class CompDeepStorage : ThingComp, IHoldMultipleThings.IHoldMultipleThings {
+    public class CompDeepStorage : ThingComp, IHoldMultipleThings.IHoldMultipleThings, IRenameable{
+            public string label = "";
+            public string RenamableLabel
+            {
+              get => this.label ?? this.BaseLabel;
+              set => this.label = value;
+            }
+        
+            public string BaseLabel => this.parent.def.label.CapitalizeFirst();
+        
+            public string InspectLabel => this.RenamableLabel;
+            
         //public float y=0f;
         public override IEnumerable<Gizmo> CompGetGizmosExtra() {
             foreach (Gizmo g in base.CompGetGizmosExtra()) {

--- a/DeepStorage/Deep_Storage_Building.cs
+++ b/DeepStorage/Deep_Storage_Building.cs
@@ -1,0 +1,52 @@
+using RimWorld;
+using System.Collections.Generic;
+using UnityEngine;
+using Verse;
+
+namespace LWM.DeepStorage
+{
+    class Deep_Storage_Building : Building_Storage, IRenameable
+    {
+        public Deep_Storage_Building() : base()
+        {
+        }
+
+        public string buildingLabel;
+
+        public string RenamableLabel
+        {
+            get => this.buildingLabel ?? this.BaseLabel;
+            set
+            {
+                this.buildingLabel = value;
+                SetLabelMultiplayer(buildingLabel);
+            }
+        }
+
+        public string BaseLabel
+        {
+            get => this.Label;
+        }
+
+        public string InspectLabel
+        {
+            get => this.RenamableLabel;
+        }
+        
+        [Multiplayer.API.SyncMethod] // I am informed that doing it this way is overkill
+        private void SetLabelMultiplayer(string newLabel)
+        {
+            buildingLabel = newLabel;
+        }
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+
+            if (Scribe.mode != LoadSaveMode.LoadingVars || this.buildingLabel == null)
+            {
+                Scribe_Values.Look(ref this.buildingLabel, "LWM_DS_DSU_label");
+            }
+        }
+    }
+}

--- a/DeepStorage/Dialog_CompSettings.cs
+++ b/DeepStorage/Dialog_CompSettings.cs
@@ -13,9 +13,9 @@ namespace LWM.DeepStorage
     // TODO: change this
     // TODO: only show name message if name changed
     // TODO: show new message for maxNumStacks changing
-	public class Dialog_CompSettings : Dialog_Rename
+	public class Dialog_CompSettings : Dialog_Rename<CompDeepStorage>
 	{
-		public Dialog_CompSettings(CompDeepStorage cds)
+		public Dialog_CompSettings(CompDeepStorage cds): base(cds)
 		{
 			this.cds = cds;
 			this.curName = cds.parent.Label;
@@ -173,7 +173,7 @@ namespace LWM.DeepStorage
             return true;
         }
 
-        protected override void SetName(string name)
+        protected void SetName(string name)
         {
             this.cds.SetLabel(name);
             Messages.Message("LWM_DSU_GainsName".Translate(this.cds.parent.def.label, cds.parent.Label),

--- a/DeepStorage/Dialog_RenameDSU.cs
+++ b/DeepStorage/Dialog_RenameDSU.cs
@@ -6,9 +6,9 @@ using UnityEngine;
 namespace LWM.DeepStorage
 {
     // ripped shamelessly from Dialog_RenameZone
-    public class Dialog_RenameDSU : Dialog_Rename
+    public class Dialog_RenameDSU : Dialog_Rename<CompDeepStorage>
     {
-        public Dialog_RenameDSU(CompDeepStorage cds)
+        public Dialog_RenameDSU(CompDeepStorage cds): base(cds)
         {
             this.cds = cds;
             this.curName = cds.parent.Label;
@@ -27,7 +27,7 @@ namespace LWM.DeepStorage
             return true;
         }
 
-        protected override void SetName(string name)
+        protected void SetName(string name)
         {
             this.cds.buildingLabel = name;
             Messages.Message("LWM_DSU_GainsName".Translate(this.cds.parent.def.label, cds.parent.Label),

--- a/DeepStorage/Dialog_RenameDSU.cs
+++ b/DeepStorage/Dialog_RenameDSU.cs
@@ -6,12 +6,15 @@ using UnityEngine;
 namespace LWM.DeepStorage
 {
     // ripped shamelessly from Dialog_RenameZone
-    public class Dialog_RenameDSU : Dialog_Rename<CompDeepStorage>
+    public class Dialog_RenameDSU : Dialog_RenameBuildingStorage
     {
-        public Dialog_RenameDSU(CompDeepStorage cds): base(cds)
+        public Dialog_RenameDSU(IRenameable cds): base(cds)
         {
-            this.cds = cds;
-            this.curName = cds.parent.Label;
+            forcePause = true;
+            doCloseX = true;
+            closeOnClickedOutside = true;
+            absorbInputAroundWindow = true;
+            closeOnClickedOutside = true;
         }
 
         // ... Actually, whatever, name it whatever you want.
@@ -25,13 +28,6 @@ namespace LWM.DeepStorage
                 return result;
             }
             return true;
-        }
-
-        protected void SetName(string name)
-        {
-            this.cds.buildingLabel = name;
-            Messages.Message("LWM_DSU_GainsName".Translate(this.cds.parent.def.label, cds.parent.Label),
-                             MessageTypeDefOf.TaskCompletion, false);
         }
 
         public override Vector2 InitialSize
@@ -49,15 +45,22 @@ namespace LWM.DeepStorage
             if (Widgets.ButtonText(new Rect(15f, inRect.height - 35f - 15f - 50f, inRect.width - 15f - 15f, 35f), "ResetButton".Translate(),
                                    true, false, true))
             {
-                this.SetName("");
+                this.curName = null;
+                this.OnRenamed(null);
                 Find.WindowStack.TryRemove(this, true);
             }
 
         }
+        
+        protected override void OnRenamed (string name)
+        {
+            if (string.IsNullOrEmpty(name) && this.renaming != null)
+            {
+                this.renaming.RenamableLabel = null;
+            }
+        }
         // TODO:  Make a nice button, eh?
         // override InitialSize to make it bigger
         // override DoWindowContents to add a new button on top of "Okay" that says "reset"?
-
-        private CompDeepStorage cds;
     }
 }

--- a/DeepStorage/ModInit.cs
+++ b/DeepStorage/ModInit.cs
@@ -7,7 +7,7 @@ namespace LWM.DeepStorage {
     [StaticConstructorOnStartup]
     public static class ModInit {
         static ModInit() {
-            Log.Message("LWM Update: stable(ish) 1.4");
+            Log.Message("LWM Update: stable(ish) 1.5");
             // Thanks to Static Constructor On Startup, all defs should be loaded now
             RemoveAnyMultipleCompProps();
             LWM.DeepStorage.Settings.DefsLoaded();

--- a/DeepStorage/Patch_Building_Storage_Gizmos.cs
+++ b/DeepStorage/Patch_Building_Storage_Gizmos.cs
@@ -11,26 +11,26 @@ namespace LWM.DeepStorage
 {
     /***************************************************
      * Patch Building_Storage's GetGizmos()
-     * 
+     *
      * Problem: If you have 345435 items in storage, your screen will fill up
      *   with those cute little bracket markers "Select stored item" thingys.
      *   Which is not great.  They are fantastic gizmos, but for enthusiastic
      *   hoarders, they are a problem.
-     * 
+     *
      * Goal: Patch the Gizmos to only show, say 10 or something.
-     * 
+     *
      * Complication: GetGizmos is an IEnumerable. Patching them sucks...
-     * 
+     *
      * Realistic Goal: only show those Gizmos if there are less than, say, 10
      *   Heck, it's easy enough to make it a mod setting.  Only show if there
      *   are less than 5, 10, 0, etc.  0 can be "don't show them at all" - an
-     *   easy first step!    
-     * 
+     *   easy first step!
+     *
      * Solution: Transpile.  The code to produce "select stored item" gizmos
      *   is inside an `if (Find.Selector.NumSelected == 1)` block.  And that
      *   `NumSelected`? That is in ONE PLACE in the code and is easy to find
      *   AND has a branch to skip those gizmos!
-     *     
+     *
      */
     [HarmonyPatch]
     public static class Patch_Building_Storage_Gizmos
@@ -39,19 +39,41 @@ namespace LWM.DeepStorage
         //  X for "show if <= X items in this storage building
         static public int cutoffBuildingStorageGizmos = cutoffDefault; // -1 means don't change anything
         public const int cutoffDefault = 12;
+
         static bool Prepare(Harmony instance)
         {
+            try
+            {
+                var method = typeof(RimWorld.Building_Storage).GetNestedType("<GetGizmos>d__52", AccessTools.all)
+                    .GetMethod("MoveNext", AccessTools.all);
+
+                if (method == null)
+                {
+                    Log.Warning(
+                        "LWM.DeepStorage: Transpiler could not find \"<GetGizmos>d__52\" :( -> skip Gizmos patch");
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Warning(
+                    "LWM.DeepStorage: Transpiler could not find \"<GetGizmos>d__52\" :( -> skip Gizmos patch");
+                return false;
+            }
+
+
             return cutoffBuildingStorageGizmos >= 0; // 0 means we transpile away, higher number means we need to check
         }
-        static MethodBase TargetMethod()//The target method is found using the custom logic defined here
+
+        static MethodBase TargetMethod() //The target method is found using the custom logic defined here
         {
             // So IEnumerables suck.
             // There is a hidden IL class inside BuildingStorage that GetGizmos uses for the IEnumerable
             //   In the IL it's listed as <GetGizmos>d__43, and the method we want to patch is from that
             //   class.  It's called MoveNext.  If we are lucky, we can do it ALL in one go.
-            var method = typeof(RimWorld.Building_Storage).GetNestedType("<GetGizmos>d__43", AccessTools.all)
-                    .GetMethod("MoveNext", AccessTools.all);
-            if (method == null) Log.Error("LWM.DeepStorage: Transpiler could not find \"<GetGizmos>d__43\" :( ");
+            var method = typeof(RimWorld.Building_Storage).GetNestedType("<GetGizmos>d__52", AccessTools.all)
+                .GetMethod("MoveNext", AccessTools.all);
+            if (method == null) Log.Error("LWM.DeepStorage: Transpiler could not find \"<GetGizmos>d__52\" :( ");
             return method;
             /* Another way to go about it, if we ever need it:
              *   (above HAS failed before (perhaps in earlier versions of Harmony?)
@@ -61,6 +83,7 @@ namespace LWM.DeepStorage
                                  .FirstOrDefault(t => t.Name.Contains("MoveNext"));
               */
         }
+
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructionsEnumerable)
         {
             var get_Selector = typeof(Verse.Find).GetMethod("get_Selector");
@@ -75,7 +98,7 @@ namespace LWM.DeepStorage
                  * [Selector].get_NumSelected()
                  * load 1
                  * branch if not equal (to skip this set of Gizmos!)
-                 *   // this branch has the imporant label we want!!                
+                 *   // this branch has the imporant label we want!!
                  */
                 if (instructions[i].opcode == OpCodes.Call // from the IL code
                     && instructions[i].OperandIs(get_Selector)
@@ -89,13 +112,15 @@ namespace LWM.DeepStorage
                         yield return instructions[i];
                         continue;
                     }
+
                     found1 = true;
                     if (cutoffBuildingStorageGizmos < 1) // we want to skip this ENTIRE SECTION
                     {
                         yield return new CodeInstruction(OpCodes.Br, skipGizmosLabel);
                         i = i + 3; // now pointing at the branch not equal
-                        continue;  // we returned something replacing those 4 instructions
+                        continue; // we returned something replacing those 4 instructions
                     }
+
                     //Log.Message("About to Return " + i + ": " + instructions[i].opcode + " " + instructions[i].operand);
                     yield return instructions[i]; // Find.Selector
                     i++;
@@ -114,17 +139,17 @@ namespace LWM.DeepStorage
                      *     if (IsOverCutoff(this.slotGroup.HeldThings.GetEnumerator)) branch skipGizmosLabel
                      * That's relatively easy.  Why?  Because the next 5 IL fields give us that
                      * Enumerator! ...Unless someone else patches the exact same spot and changes
-                     * those IL codes :laughs::cries::facepalm:&c                    
+                     * those IL codes :laughs::cries::facepalm:&c
                      * So how about we just call those instructions directly:
                      */
                     yield return new CodeInstruction(OpCodes.Ldloc_2); // storage building in question
                     yield return new CodeInstruction(OpCodes.Ldfld, typeof(Building_Storage)
-                                        .GetField("slotGroup", AccessTools.all)); // .slotGroup
+                        .GetField("slotGroup", AccessTools.all)); // .slotGroup
                     yield return new CodeInstruction(OpCodes.Callvirt, typeof(SlotGroup)
-                                        .GetMethod("get_HeldThings", AccessTools.all)); // .HeldThings
+                        .GetMethod("get_HeldThings", AccessTools.all)); // .HeldThings
                     //Log.Warning("Call over threshold");
                     yield return new CodeInstruction(OpCodes.Call,
-                                 typeof(Patch_Building_Storage_Gizmos).GetMethod("IsOverThreshold", AccessTools.all));
+                        typeof(Patch_Building_Storage_Gizmos).GetMethod("IsOverThreshold", AccessTools.all));
                     //Log.Warning("Call skip true");
                     yield return new CodeInstruction(OpCodes.Brtrue, skipGizmosLabel);
                 }
@@ -135,9 +160,11 @@ namespace LWM.DeepStorage
                     yield return instructions[i];
                 }
             } // end instructions for loop
+
             if (!found1) Log.Warning("LWM.DeepStorage: failed to Transpile Gizmos");
             yield break;
         }
+
         // Simple and quick way to count if something is over the cuttoff threshold
         static bool IsOverThreshold(IEnumerable<Verse.Thing> things)
         {
@@ -148,17 +175,20 @@ namespace LWM.DeepStorage
                     continue;
                 return false;
             }
+
             return true;
         }
+
         // Simple and quick way to count if something is over the cuttoff threshold
         static bool IsOverThresholdX(IEnumerator<Verse.Thing> thingsEnumerator)
         {
-            for (int i=0; i<=cutoffBuildingStorageGizmos; i++)
+            for (int i = 0; i <= cutoffBuildingStorageGizmos; i++)
             {
                 if (thingsEnumerator.MoveNext())
                     continue;
                 return false;
             }
+
             return true;
         }
     }

--- a/_Mod/LWM.DeepStorage/Defs/Deep_Storage.xml
+++ b/_Mod/LWM.DeepStorage/Defs/Deep_Storage.xml
@@ -143,7 +143,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
   <ThingDef Name="LWM_DeepStorage" ParentName="FurnitureBase" Abstract="true">
     <!--  Old approach:  Class="LWM.DeepStorage.DeepStorageDef"; using a comp is better>-->
     <defName>LWM_DeepStorage</defName><!-- this defname doesn't actually exist in-game, does it? -->
-    <thingClass>Building_Storage</thingClass>
+    <thingClass>LWM.DeepStorage.Deep_Storage_Building</thingClass>
 
     <altitudeLayer>Building</altitudeLayer>
     <passability>PassThroughOnly</passability>
@@ -191,6 +191,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 
     <filthLeaving>Filth_RubbleBuilding</filthLeaving>
     <building>
+      <groupingLabel>Building Storage</groupingLabel><!-- Might be overridden -->
       <preventDeteriorationOnTop>true</preventDeteriorationOnTop><!-- Might be overridden -->
       <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty><!-- Might be overridden -->
       <defaultStorageSettings>
@@ -212,7 +213,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
     <defName>LWM_BigShelf</defName><!-- name change to reduce chance of mod conflict.  See Updates.cs -->
     <label>Double Shelf</label>
     <description>A shelf for storing miscellaneous items, from artillery shells to artwork, from bionic arms to bricks, from chairs to corpses.  It doesn't ask questions, it just stores things.\n\nItems stored in this will not deteriorate, even if outside.\n\nThis shelf holds twice as much as the regular one.</description>
-    <thingClass>Building_Storage</thingClass>
     <graphicData>
       <texPath>Things/Building/Furniture/Shelf</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -238,6 +238,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
     <size>(2,1)</size>
     <defaultPlacingRot>South</defaultPlacingRot>
     <building>
+      <groupingLabel>Double Shelf</groupingLabel>
       <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
       <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
       <defaultStorageSettings>
@@ -258,7 +259,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
     <defName>LWM_VeryBigShelf</defName>
     <label>Tall Shelves</label>
     <description>A set of tall covered shelves for storing miscellaneous items, from artillery shells to artwork, from bionic arms to bricks, from chairs to corpses.  It doesn't ask questions, it just stores things.\n\nPawns access the top shelves using a small rolling ladder (currently not pitured), so while many things can be stored here, it can take a while if you're putting a lot of tiny bottles on the top shelf.  Items stored in this will not deteriorate, even if outside.\n\nNote:  Use your own judgement about what you put here.  Grand Sculptures?  Probably don't ACTUALLY fit.  But if that's what you want here, you play you!</description>
-    <thingClass>Building_Storage</thingClass>
     <graphicData>
       <texPath>VBig_Shelf</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -286,6 +286,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
     <size>(2,1)</size>
     <defaultPlacingRot>South</defaultPlacingRot>
     <building>
+      <groupingLabel>Tall Shelves</groupingLabel>
       <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
       <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
       <defaultStorageSettings>
@@ -329,6 +330,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
     </stuffCategories>
     <costStuffCount>75</costStuffCount><!-- lots of shelves? -->
     <building>
+      <groupingLabel>Meal Rack</groupingLabel>
       <fixedStorageSettings>
         <filter>
           <categories>
@@ -380,6 +382,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
       <Flammability>1.0</Flammability>
     </statBases>
     <building>
+      <groupingLabel>Food Basket</groupingLabel>
       <fixedStorageSettings>
         <filter>
           <categories>
@@ -437,6 +440,7 @@ Note that you can only fit so many giant corpses into one space, even if you sta
     </stuffCategories>
     <costStuffCount>75</costStuffCount>
     <building>
+      <groupingLabel>Meat Hook</groupingLabel>
       <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
       <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
       <fixedStorageSettings>
@@ -503,6 +507,7 @@ Note that you can only fit so many giant corpses into one space, even if you sta
     </stuffCategories>
     <costStuffCount>85</costStuffCount>
     <building>
+      <groupingLabel>Hayloft</groupingLabel>
       <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
       <fixedStorageSettings>
         <filter>
@@ -556,6 +561,7 @@ Note that you can only fit so many giant corpses into one space, even if you sta
     <costStuffCount>90</costStuffCount>
     <costList><Steel>25</Steel></costList><!--Wish I could do steel OR wood-->
     <building>
+      <groupingLabel>Hampers</groupingLabel>
       <fixedStorageSettings>
         <filter>
           <!-- No "Fabric" here - I think hampers are a terrible say to store
@@ -623,6 +629,7 @@ Note that you can only fit so many giant corpses into one space, even if you sta
     </stuffCategories>
     <costStuffCount>65</costStuffCount>
     <building>
+      <groupingLabel>Pallet</groupingLabel>
       <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
       <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
       <fixedStorageSettings>
@@ -671,6 +678,7 @@ Note that you can only fit so many giant corpses into one space, even if you sta
       <Cloth>40</Cloth>
     </costList>
     <building>
+      <groupingLabel>Pallet Covered</groupingLabel>
       <preventDeteriorationOnTop>true</preventDeteriorationOnTop>
       <ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
       <fixedStorageSettings>
@@ -724,6 +732,7 @@ Note: tossing large amounts of steel in willy-nilly means that it takes a while 
     </stuffCategories>
     <costStuffCount>90</costStuffCount>
     <building>
+      <groupingLabel>Skip</groupingLabel>
       <ignoreStoredThingsBeauty>false</ignoreStoredThingsBeauty>
       <preventDeteriorationOnTop>false</preventDeteriorationOnTop>
       <fixedStorageSettings>
@@ -784,6 +793,7 @@ Note: tossing large amounts of steel in willy-nilly means that it takes a while 
       <Flammability>1.0</Flammability>
     </statBases>
     <building>
+      <groupingLabel>Medicine Cabinet</groupingLabel>
       <fixedStorageSettings>
         <filter>
           <categories>
@@ -835,6 +845,7 @@ Note: tossing large amounts of steel in willy-nilly means that it takes a while 
     </stuffCategories>
     <costStuffCount>50</costStuffCount>
     <building>
+      <groupingLabel>Clothing Rack</groupingLabel>
       <fixedStorageSettings>
         <filter>
           <categories>
@@ -886,6 +897,7 @@ Note: tossing large amounts of steel in willy-nilly means that it takes a while 
 	</stuffCategories>
 	<costStuffCount>300</costStuffCount>
 	<building>
+        <groupingLabel>Safe</groupingLabel>
 		<preventDeteriorationOnTop>true</preventDeteriorationOnTop>
 		<ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
 		<fixedStorageSettings>

--- a/_Mod/LWM.DeepStorage/Patches/AddNewUnits_RimFridge.xml
+++ b/_Mod/LWM.DeepStorage/Patches/AddNewUnits_RimFridge.xml
@@ -31,6 +31,9 @@
         <pathCost>80</pathCost>
 	<fillPercent>0.5</fillPercent><!-- decent to hide behind -->
 	<castEdgeShadows>true</castEdgeShadows>
+		  <building>
+			  <groupingLabel>Deep Refrigerator</groupingLabel>
+		  </building>
 	<costList>
 	  <Steel>80</Steel>
 	  <ComponentIndustrial>3</ComponentIndustrial>


### PR DESCRIPTION
Rimworld 1.5 added a `groupingLabel` property on XML defs.  
This property allows a building to be categorized for the `Take to XXX` destination in any workshop (cf `Rimworld.Dialog_BillConfig#206`).
We can also group any `Building_Storage` with others to create new storage areas.  

To implement these features, each building needs to implement a `Thing` extending `Building_Storage` **and** `IRenamable` instead of only `Building_Storage` before 1.5.  
Adding `IRenamable` on the building add the possibility to rename directly the storage building by creating a group on the rename. There's also a rename option available in the bottom-left drescription window (next to the icon `i`).

This PR is a starting point to implement these features. By moving the renaming logic, I don't know if `Dialog_CompSettings` must be kept.

This work is based on the one from [@just-harry on RimFridge](https://github.com/just-harry/rimworld-rimfridge-now-with-shelves/commit/77e530e0675e518a7f32847c58cdda3eca919c01).

Missing : 
- translations
- removing old code ? Should the mod always allow user to do some group buildings configuration out of the current possibility offered by Rimworld 1.5 ?