### PR TITLE
Fix merge between 1.5 and cache branches

### DIFF
--- a/DeepStorage/CompDeepStorage.cs
+++ b/DeepStorage/CompDeepStorage.cs
@@ -17,7 +17,7 @@ namespace LWM.DeepStorage
             public string RenamableLabel
             {
               get => this.buildingLabel.NullOrEmpty() ? this.BaseLabel : this.buildingLabel;
-              set => this.label = value;TODO
+              set => this.label = value;
             }
         
             public string BaseLabel => this.parent.def.label.CapitalizeFirst();

--- a/DeepStorage/Dialog_CompSettings.cs
+++ b/DeepStorage/Dialog_CompSettings.cs
@@ -11,19 +11,10 @@ namespace LWM.DeepStorage
 	// ripped shamelessly from Dialog_RenameZone
     // TODO: Why bother with dialog_rename? I have it all here; just remove other dialog
     // TODO: show new message for maxNumStacks changing
-<<x<<<<< master // Why can't I merge these conflicts into my 1.5??  Ugh. I'm sorry AamuLumi, this is ugly
+    // NOTE: Any changes that happen can be directed to the Comp - it'll handle any weird storage group things
 	public class Dialog_CompSettings : Dialog_Rename<CompDeepStorage>
 	{
-		public Dialog_CompSettings(CompDeepStorage cds): base(cds)
-		{
-			this.cds = cds;
-			this.curName = cds.parent.Label;
-===x====
-    // NOTE: Any changes that happen can be directed to the Comp - it'll handle any weird storage group things
-	public class Dialog_CompSettings : Dialog_Rename
-	{
-        public Dialog_CompSettings(ThingWithComps parent)
-        //public Dialog_CompSettings(CompDeepStorage cds, Thing parent = null)
+        public Dialog_CompSettings(ThingWithComps parent): base(DSStorageGroupUtility.GetOrTryMakeCompFrom(parent))
         {
             this.cds = DSStorageGroupUtility.GetOrTryMakeCompFrom(parent);
             this.parent = parent;
@@ -31,7 +22,6 @@ namespace LWM.DeepStorage
             this.curName = cds.buildingLabel;
             if (curName == "") curName = DSStorageGroupUtility.GetDefaultLabelFor(parent); // same as below
             origName = curName;
->>>>x>>> 1.5-initial
 		}
 
 		public override Vector2 InitialSize

--- a/DeepStorage/Patch_EditWindow_DebugInspector.cs
+++ b/DeepStorage/Patch_EditWindow_DebugInspector.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using HarmonyLib;
 using System.Reflection;
 using System.Reflection.Emit;
+using LudeonTK;
 using UnityEngine;
 namespace LWM.DeepStorage
 {
@@ -14,7 +15,7 @@ namespace LWM.DeepStorage
      *   the Debug Inspector is being used
      */
 #if DEBUG
-    [HarmonyPatch(typeof(Verse.EditWindow_DebugInspector), "CurrentDebugString")]
+    [HarmonyPatch(typeof(EditWindow_DebugInspector), "CurrentDebugString")]
     public static class Patch_EditWindow_DebugInspector
     {
         public static string Postfix(string __result)


### PR DESCRIPTION
Hey !

I finished the merge between 1.5 and cache.
The problem in the `Dialog_CompSettings` was the `base()` constructor not called with the good object.

At least, it compiles and runs. But there's some bugs between cache and Rimworld 1.5 : after building a DS furniture, pawn can't carry any item to the furniture. The right-click menu says there's no free space to store the item.
Furnitures locates correctly item in the region with the debug functon `Items in region`, so I suspect there's a bug on the carry job or the free space compute for carrying item. But I didn't find how to fix it.

Tell me if you see something I can do to help you ! 