### PR TITLE
Update Compatibility_Dubs_Rimatomics.xml

### DIFF
--- a/_Mod/LWM.DeepStorage/Patches/Compatibility_Dubs_Rimatomics.xml
+++ b/_Mod/LWM.DeepStorage/Patches/Compatibility_Dubs_Rimatomics.xml
@@ -7,14 +7,24 @@
         </mods>
         <match Class="PatchOperationSequence">
             <operations>
-                <li Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[defName="LWM_Pallet"]/building/fixedStorageSettings/filter</xpath>
-                    <value>
-                        <thingDefs>
+                <li Class="PatchOperationConditional">
+                    <xpath>/Defs/ThingDef[defName="LWM_Pallet"]/building/fixedStorageSettings/filter/thingDefs</xpath>
+                    <nomatch Class="PatchOperationAdd">
+                        <xpath>/Defs/ThingDef[defName="LWM_Pallet"]/building/fixedStorageSettings/filter</xpath>
+                        <value>
+                            <thingDefs>
+                                <li>RailgunSabot</li>
+                                <li>RailgunSabotDU</li>
+                            </thingDefs>
+                        </value>
+                    </nomatch>
+                    <match Class="PatchOperationAdd">
+                        <xpath>/Defs/ThingDef[defName="LWM_Pallet"]/building/fixedStorageSettings/filter/thingDefs</xpath>
+                        <value>
                             <li>RailgunSabot</li>
                             <li>RailgunSabotDU</li>
-                        </thingDefs>
-                    </value>
+                        </value>
+                    </match>
                 </li>
                 <li Class="LWM.DeepStorage.PatchMessage">
                     <message>LWM Deep Storage: activated compatibility patch for Dubs Rimatomics</message>


### PR DESCRIPTION
**Description:**
This change fixes an issue with the compatibility patches for Dubs Bad Hygiene and Dubs Rimatomics.

Currently a hardcoded dependency exists where Deep Storage Rimatomics patch needs to run prior to the Deep Storage Hygiene patch (which has some conditional operations to deal with duplication). 

Unfortunately, despite the load order being set appropriately, the Hygiene patch somehow executes first - resulting in the error `XML error: Duplicate XML node name thingDefs in this XML block`. (Both patches are trying to insert thingDefs into LWM_Pallet, but only Hygiene conditionally checks first to avoid duplication).

**Log:** 
https://gist.github.com/HugsLibRecordKeeper/8014f17275202ac0b3f99945627dbb94

In order to solve this problem, I've added a similar conditional statement as seen in the Hygiene patch to the Rimatomics patch, making it safe for either to run first.