### PR TITLE
Fix "Exception in JobDriver tick"

### DIFF
--- a/DeepStorage/Patch_Frame_MultipleTimes.cs
+++ b/DeepStorage/Patch_Frame_MultipleTimes.cs
@@ -32,8 +32,16 @@ namespace LWM.DeepStorage
         static void Prefix(Frame __instance)
         {
             compDS = null;
-            if (__instance == null) Log.Error("null instance");
-            if (__instance.Map == null) Log.Error("Null map for " + __instance);
+            if (__instance == null)
+            {
+                Log.Error("null instance");
+                return;
+            }
+            if (__instance.Map == null)
+            {
+                Log.Error("Null map for " + __instance);
+                return;
+            }
             __instance.Map.GetComponent<MapComponentDS>().settingsForBlueprintsAndFrames.Remove(__instance, out compDS);
         }
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)


### PR DESCRIPTION
Exception gets thrown when Frame has already been deleted: by another Prefix on same method, etc.

Common "bug" reported on Fertile Fields mod, which does in fact Prefix the same method and can delete the Frame before passing control.