### PR TITLE
Fixes conflict with the Fertile Fields patch. Also solves PR #158

### DIFF
--- a/DeepStorage/Patch_Frame_MultipleTimes.cs
+++ b/DeepStorage/Patch_Frame_MultipleTimes.cs
@@ -22,6 +22,7 @@ namespace LWM.DeepStorage
         }
     }
 
+    [HarmonyBefore(new string[] { "net.rainbeau.rimworld.mod.fertilefields" })]
     [HarmonyPatch(typeof(RimWorld.Frame), "CompleteConstruction")]
     public static class Patch_Frame_CompleteConstruction
     {
@@ -32,8 +33,16 @@ namespace LWM.DeepStorage
         static void Prefix(Frame __instance)
         {
             compDS = null;
-            if (__instance == null) Log.Error("null instance");
-            if (__instance.Map == null) Log.Error("Null map for " + __instance);
+            if (__instance == null)
+            {
+                Log.Error("null instance");
+                return;
+            }
+            if (__instance.Map == null)
+            {
+                Log.Error("Null map for " + __instance);
+                return;
+            }
             __instance.Map.GetComponent<MapComponentDS>().settingsForBlueprintsAndFrames.Remove(__instance, out compDS);
         }
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)


### PR DESCRIPTION
As others have pointed out, there's a small conflict with [Fertile Fields](https://steamcommunity.com/sharedfiles/filedetails/?id=3225843229) because the mods patch the same method, but FF goes first and deletes the object you're trying to get the Map property from. It causes an error when a pawn completes the construction job and also results in a momentary stutter for that pawn. The game is able to recover from it and nothing is really lost (in game terms), but multiply that stutter by the amount of times one needs to fertilize their fields and you get a significant impact! This is a one-line solution that simply ensures your patch runs before theirs.